### PR TITLE
fix: Server should only delete the connection that was closed

### DIFF
--- a/src/_sync/constants.ts
+++ b/src/_sync/constants.ts
@@ -1,4 +1,3 @@
-import {createActions} from 'redux-decorated'
 import {Protocol, WebSocketConnection} from '../common'
 
 export const dispatchAction = 'dispatchAction'
@@ -25,13 +24,13 @@ export const actions = {
   initialSyncedState: {
     type: 'initialSyncedState',
     meta: {
-      toClient: true
+      toClient: true,
     },
   },
   updateSyncedState: {
     type: 'updateSyncedState',
     meta: {
-      toClient: true
+      toClient: true,
     },
   },
 }

--- a/src/_sync/get-new-versions.ts
+++ b/src/_sync/get-new-versions.ts
@@ -21,5 +21,5 @@ export function getNewVersions(clientVersions, getState: () => any, skipVersion:
     })
   }
 
-  return updated && newVersions;
+  return updated && newVersions
 }

--- a/src/_sync/protocol.ts
+++ b/src/_sync/protocol.ts
@@ -9,7 +9,7 @@ type CheckVersionFunction = (
 
 export function checkVersionFunction(skipVersion: string[]): CheckVersionFunction {
   return (getState, clientVersions, respond) => {
-    const newVersions = getNewVersions(clientVersions, getState, skipVersion);
+    const newVersions = getNewVersions(clientVersions, getState, skipVersion)
 
     if (newVersions) {
       respond({

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,6 +1,7 @@
 import {Action, Actions, Protocol, WebSocketConnection} from './common'
 
 export class WebSocketClient implements WebSocketConnection {
+  readonly isServer = false
   protocols = {}
   socket: WebSocket
   open = false
@@ -10,7 +11,8 @@ export class WebSocketClient implements WebSocketConnection {
   }
 
   registerProtocol(name: string, protocol: Protocol) {
-    protocol.send = (message) => this.socket.send(JSON.stringify({type: name, data: message}))
+    protocol.send = message => this.socket.send(JSON.stringify({type: name, data: message}))
+
     this.protocols[name] = protocol
 
     if (this.open && protocol.onopen) {

--- a/src/common.ts
+++ b/src/common.ts
@@ -5,6 +5,7 @@ export interface Protocol {
 }
 
 export interface WebSocketConnection {
+  isServer: boolean
   registerProtocol(name: string, protocol: Protocol): void
 }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -3,7 +3,8 @@ import {server as WebSocket, connection} from 'websocket'
 import {Action, Actions, Protocol, WebSocketConnection} from './common'
 
 export class WebSocketServer implements WebSocketConnection {
-  connections: Array<connection> = []
+  readonly isServer = true
+  readonly connections: Array<connection> = []
   protocols = {}
 
   constructor(server: WebSocket) {
@@ -30,7 +31,7 @@ export class WebSocketServer implements WebSocketConnection {
       })
 
       connection.on('close', () => {
-        this.connections.splice(this.connections.indexOf(connection))
+        this.connections.splice(this.connections.indexOf(connection), 1)
       })
     })
   }

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -18,8 +18,9 @@ export const syncStoreEnhancer = (settings: Settings) => next => (reducer, initi
   settings.socket.registerProtocol('sync', protocol)
 
   const dispatch = compose(
-    diffingMiddleware(settings, protocol)(store),
-    trackRehydrationMiddleware(settings, protocol)(store)
+    settings.socket.isServer
+      ? diffingMiddleware(settings, protocol)(store)
+      : trackRehydrationMiddleware(settings, protocol)(store)
   )(store.dispatch)
 
   return Object.assign({}, store, {dispatch})

--- a/test/specs/server.ts
+++ b/test/specs/server.ts
@@ -17,7 +17,7 @@ describe('WebSocketServer', () => {
   it('should accept redux-websocket connections', () => {
     const connection = {on} as any
     const request = {accept: createMockFunction().returns(connection), origin: 'origin'}
-    const socket = new WebSocketServer(socketMock)
+    new WebSocketServer(socketMock)
 
     socketMock.onrequest(request)
 
@@ -91,6 +91,23 @@ describe('WebSocketServer', () => {
       type: 'test',
       data: 'message2',
     })])
+  })
+
+  it('should only delete the connection that was closed', () => {
+    const connection = {on} as any
+    const connection2 = {on} as any
+    const request = {accept: createMockFunction().returns(connection)}
+    const request2 = {accept: createMockFunction().returns(connection2)}
+    const socket = new WebSocketServer(socketMock) as any
+
+    socketMock.onrequest(request)
+    socketMock.onrequest(request2)
+
+    connection.onclose()
+
+    expect(socket.connections.length).to.equal(1)
+    expect(socket.connections).to.not.include(connection)
+    expect(socket.connections).to.include(connection2)
   })
 })
 

--- a/typings.d.ts
+++ b/typings.d.ts
@@ -6,6 +6,7 @@ declare module 'redux-websocket/lib/common' {
   }
 
   export interface WebSocketConnection {
+    isServer: boolean
     registerProtocol(name: string, protocol: Protocol): void;
   }
 
@@ -23,6 +24,7 @@ declare module 'redux-websocket/lib/client' {
   import {Actions, Protocol, WebSocketConnection} from 'redux-websocket/lib/common';
 
   export class WebSocketClient implements WebSocketConnection {
+    isServer: boolean
     protocols: {};
     private socket: WebSocket;
     constructor(url: any);
@@ -37,9 +39,10 @@ declare module 'redux-websocket/lib/client' {
 
 declare module 'redux-websocket/lib/server' {
   import {Actions, Protocol, WebSocketConnection} from 'redux-websocket/lib/common';
-  import {server as WebSocket} from 'websocket';
+  import {server as WebSocket, connection} from 'websocket';
 
   export class WebSocketServer implements WebSocketConnection {
+    isServer: boolean
     constructor(webSocket: WebSocket);
     registerProtocol(name: string, protocol: Protocol): void;
   }


### PR DESCRIPTION
The server should only delete the connection that was closed. The diffingMiddleware should only be used on the server and the trackRehydrationMiddleware should only be used on the client.
